### PR TITLE
improve documentation

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -32,9 +32,6 @@ workflows:
         - path: ./_tmp
         - is_create_path: true
     - path::./:
-        title: Genymotion Cloud SaaS Start
-        description: |-
-           Start genymotion Cloud SaaS Android Devices
         run_if: "true"
         inputs:
         - gmcloud_saas_email: $GMCLOUD_SAAS_EMAIL
@@ -49,9 +46,7 @@ workflows:
             echo "The value of 'GMCLOUD_SAAS_INSTANCE_UUID' is: $GMCLOUD_SAAS_INSTANCE_UUID
             echo "The value of 'GMCLOUD_SAAS_INSTANCE_ADB_SERIAL_PORT' is: $GMCLOUD_SAAS_INSTANCE_ADB_SERIAL_PORT
     - path::../bitrise-step-genymotion-cloud-saas-stop:
-          title: "Genymotion Cloud SaaS Stop"
-          description: |-
-           Stop genymotion Cloud SaaS Android Devices
+
           inputs:
           - gmcloud_saas_instance_uuid: $GMCLOUD_SAAS_INSTANCE_UUID
 

--- a/step.yml
+++ b/step.yml
@@ -8,11 +8,11 @@
 # - Bitrise CLI guides: http://devcenter.bitrise.io/bitrise-cli/
 
 title: |-
-  genymotion-cloud-saas-start
+  Genymotion Cloud Start Android Devices
 summary: |
-  Start Genymotion Cloud SaaS Android devices
+  Start Genymotion Cloud SaaS instances
 description: |
-  Start Genymotion Cloud SaaS Android devices
+  Start Genymotion Cloud SaaS instances, you need to create an account first on [https://cloud.geny.io](https://cloud.geny.io)
 website: https://github.com/genymobile/bitrise-step-genymotion-cloud-saas-start
 source_code_url: https://github.com/genymobile/bitrise-step-genymotion-cloud-saas-start
 support_url: https://github.com/genymobile/bitrise-step-genymotion-cloud-saas-start/issues
@@ -29,10 +29,10 @@ host_os_tags:
 # You can find more information about project type tags in the Step Development Guideline:
 # https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md
 #
-# project_type_tags:
+project_type_tags:
 #   - ios
 #   - macos
-#   - android
+  - android
 #   - xamarin
 #   - react-native
 #   - cordova
@@ -43,6 +43,7 @@ host_os_tags:
 # https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md
 type_tags:
   - utility
+  - test
 
 is_requires_admin_user: true
 is_always_run: false
@@ -69,7 +70,7 @@ inputs:
       title: Genymotion Cloud SaaS email
       summary: ""
       description: |-
-        Email of your Genymotion Cloud SaaS account
+        Email of your Genymotion Cloud SaaS account, if you don't have an account please create it first on [https://cloud.geny.io](https://cloud.geny.io)
       is_required: true
 
   - gmcloud_saas_password: ""


### PR DESCRIPTION
Improve the step's title, we decided to add Android devices in the title of the step to allow the user to find the plug-in if he types "Android" in the search box.

I've  added a link to inform the user that he must first create an account on cloud.geny.io.

I've also removed some useless informations on the bitrise.yml, because these informations are retrieved according the step.yml. 
 
![Screenshot from 2019-09-19 10-45-50](https://user-images.githubusercontent.com/5629552/65229416-84efc380-dacc-11e9-9942-6be99831425f.png)
