### PR TITLE
Use len(adbserialport) >=1

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func main() {
 	for cptInstance := 0; cptInstance < len(recipesList); cptInstance++ {
 		instanceName := fmt.Sprint("gminstance_bitrise_", cptInstance)
 		wg.Add(1)
-		if len(adbSerialPortList) > 1 {
+		if len(adbSerialPortList) >= 1 {
 			go startInstanceAndConnect(&wg, recipesList[cptInstance], instanceName, adbSerialPortList[cptInstance])
 		} else {
 			go startInstanceAndConnect(&wg, recipesList[cptInstance], instanceName, "")


### PR DESCRIPTION
We have found a bug when we try to start one device and configure one adb serial port. Before this fix, if we configured one adb serial port, the adb serial port was generated randomly. 

So now we check when one or more adb serial port are configured

Tested with 1 device: 
```
UUID                                  NAME                  ADB SERIAL       STATE
------------------------------------  --------------------  ---------------  -------
36c2c02b-5a83-4ff2-bdc1-b8e3c25083fb  gminstance_bitrise_0  localhost:49271  ONLINE
```

Tested with 2 devices
```
UUID                                  NAME                  ADB SERIAL       STATE
------------------------------------  --------------------  ---------------  -------
cee6845d-cbb1-405c-9d1a-4b1e15047c37  gminstance_bitrise_0  localhost:49271  ONLINE
657b5bf2-f1fe-4425-be2d-27e69075c36d  gminstance_bitrise_1  localhost:49272  ONLINE
```

