### PR TITLE
Add BuildNumber to instance name

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,10 +189,12 @@ func main() {
 	recipesList := strings.Split(c.GMCloudSaaSRecipeUUID, ",")
 	adbSerialPortList := strings.Split(c.GMCloudSaaSAdbSerialPort, ",")
 
+	buildNumber := os.Getenv("BITRISE_BUILD_NUMBER")
+
 	log.Infof("Start %d Android instances on Genymotion Cloud SaaS", len(recipesList))
 	var wg sync.WaitGroup
 	for cptInstance := 0; cptInstance < len(recipesList); cptInstance++ {
-		instanceName := fmt.Sprint("gminstance_bitrise_", cptInstance)
+		instanceName := fmt.Sprint("gminstance_bitrise_", buildNumber, "_", cptInstance)
 		wg.Add(1)
 		if len(adbSerialPortList) >= 1 {
 			go startInstanceAndConnect(&wg, recipesList[cptInstance], instanceName, adbSerialPortList[cptInstance])
@@ -204,7 +206,7 @@ func main() {
 
 	for cptInstance := 0; cptInstance < len(recipesList); cptInstance++ {
 
-		instanceName := fmt.Sprint("gminstance_bitrise_", cptInstance)
+		instanceName := fmt.Sprint("gminstance_bitrise_", buildNumber, "_", cptInstance)
 		instanceUUID, InstanceADBSerialPort := getInstanceDetails(instanceName)
 
 		instancesList = append(instancesList, instanceUUID)


### PR DESCRIPTION
Add BuildNumber to the Genymotion device name to avoid conflict when workflow are running in parrallel 

This will fix https://github.com/Genymobile/bitrise-step-genymotion-cloud-saas-start/issues/12