### PR TITLE
split ABD_SERIAL_PORT_LIST only if list is set in the worflow

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,9 +185,13 @@ func main() {
 
 	instancesList := []string{}
 	adbSerialList := []string{}
+	adbSerialPortList := []string{}
 
 	recipesList := strings.Split(c.GMCloudSaaSRecipeUUID, ",")
-	adbSerialPortList := strings.Split(c.GMCloudSaaSAdbSerialPort, ",")
+
+	if len(c.GMCloudSaaSAdbSerialPort) >= 1 {
+		adbSerialPortList = strings.Split(c.GMCloudSaaSAdbSerialPort, ",")
+	}
 
 	buildNumber := os.Getenv("BITRISE_BUILD_NUMBER")
 


### PR DESCRIPTION
When we want to start several devices without specify any ADB SERIAL PORT, the list was out of range and the build fail. 

This PR fix this issue. 