### PR TITLE
Add new paramater gmsaas_version and force default version to 1.9.0

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ app:
   envs:
   # If you want to share this step into a StepLib
   - BITRISE_STEP_ID: genymotion-cloud-saas-start
-  - BITRISE_STEP_VERSION: "0.1.5"
+  - BITRISE_STEP_VERSION: "0.1.6"
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/genymobile/bitrise-step-genymotion-cloud-saas-start.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: git@github.com:Genymobile/bitrise-steplib.git
   # Define these in your .bitrise.secrets.yml

--- a/step.yml
+++ b/step.yml
@@ -125,6 +125,15 @@ inputs:
           For example:
           `4321,4322,4323`
 
+  - gmsaas_version: "1.9.0"
+    opts:
+        title: gmsaas version
+        summary: ""
+        description: |-
+          Install a specific version of gmsaas, per default it will install the latest gmsaas compatible : 1.9.0
+
+
+
 outputs:
   - GMCLOUD_SAAS_INSTANCE_UUID:
     opts:


### PR DESCRIPTION
Since the gmsaas 1.10.0 release, we have identified issues impacting the functionality of the Bitrise step. In order to promptly address these concerns for our clients, we have implemented a solution that allows specifying the version of gmsaas to be installed.

To prevent any issues associated with version 1.10.0, we have set the default version to 1.9.0.

We will working on a major update scheduled for release soon in order to include gmsaas 1.10.0 and API Token


PR Refs : https://github.com/Genymobile/bitrise-step-genymotion-saas-install-gmsaas-cli/pull/3