### PR TITLE
Improve json parsing

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,8 +21,17 @@ workflows:
     - errcheck:
     - go-test:
 
+  run-all-tests:
+    before_run:
+    - test-credentials
+    - test-api-token
+    - test-adb-serial-port
+    - test-several-devices
+    - test-several-devices-with-adb-serial-port
 
   test-credentials:
+    title: "Test Credentials"
+    description: "This step tests that the user can login and start a device with credentials."
     steps:
     - change-workdir:
         title: Switch working dir to test / _tmp dir
@@ -56,6 +65,8 @@ workflows:
           - instance_uuid: $GMCLOUD_SAAS_INSTANCE_UUID
 
   test-api-token:
+    title: "Test API Token"
+    description: "This step tests that the user can login and start a device with the API token."
     steps:
     - change-workdir:
         title: Switch working dir to test / _tmp dir
@@ -79,6 +90,7 @@ workflows:
         inputs:
         - content: |
             #!/bin/bash
+            gmsaas --version
             echo "The value of 'GMCLOUD_SAAS_INSTANCE_UUID' is: $GMCLOUD_SAAS_INSTANCE_UUID
             echo "The value of 'GMCLOUD_SAAS_INSTANCE_ADB_SERIAL_PORT' is: $GMCLOUD_SAAS_INSTANCE_ADB_SERIAL_PORT
     - git::https://github.com/Genymobile/bitrise-step-genymotion-cloud-saas-stop.git:
@@ -89,6 +101,80 @@ workflows:
           - instance_uuid: $GMCLOUD_SAAS_INSTANCE_UUID
 
   test-adb-serial-port:
+    title: "Test ADB Serial Port"
+    description: "This step tests the connection to the specified ADB port for Genymotion devices."
+    steps:
+    - change-workdir:
+        title: Switch working dir to test / _tmp dir
+        description: |-
+          To prevent step testing issues, like referencing relative
+          files with just './some-file' in the step's code, which would
+          work for testing the step from this directory directly
+          but would break if the step is included in another `bitrise.yml`.
+        run_if: true
+        inputs:
+        - path: ./_tmp
+        - is_create_path: true
+    - path::./:
+        title: Genymotion Cloud SaaS Start
+        run_if: "true"
+        inputs:
+        - email: $GMCLOUD_SAAS_EMAIL
+        - password: $GMCLOUD_SAAS_PASSWORD
+        - recipe_uuid:
+        - adb_serial_port:
+    - script:
+        inputs:
+        - content: |
+            #!/bin/bash
+            echo "The value of 'GMCLOUD_SAAS_INSTANCE_UUID' is: $GMCLOUD_SAAS_INSTANCE_UUID
+            echo "The value of 'GMCLOUD_SAAS_INSTANCE_ADB_SERIAL_PORT' is: $GMCLOUD_SAAS_INSTANCE_ADB_SERIAL_PORT
+    - git::https://github.com/Genymobile/bitrise-step-genymotion-cloud-saas-stop.git:
+          title: "Genymotion Cloud SaaS Stop"
+          description: |-
+           Stop Genymotion Cloud SaaS Android Devices.
+          inputs:
+          - instance_uuid: $GMCLOUD_SAAS_INSTANCE_UUID
+    
+  test-several-devices:
+    title: "Test Several Devices"
+    description: "This step tests that the user can login and start several devices with credentials."
+    steps:
+    - change-workdir:
+        title: Switch working dir to test / _tmp dir
+        description: |-
+          To prevent step testing issues, like referencing relative
+          files with just './some-file' in the step's code, which would
+          work for testing the step from this directory directly
+          but would break if the step is included in another `bitrise.yml`.
+        run_if: true
+        inputs:
+        - path: ./_tmp
+        - is_create_path: true
+    - path::./:
+        title: Genymotion Cloud SaaS Start
+        run_if: "true"
+        inputs:
+        - email: $GMCLOUD_SAAS_EMAIL
+        - password: $GMCLOUD_SAAS_PASSWORD
+        - recipe_uuid: 
+        - adb_serial_port: 
+    - script:
+        inputs:
+        - content: |
+            #!/bin/bash
+            echo "The value of 'GMCLOUD_SAAS_INSTANCE_UUID' is: $GMCLOUD_SAAS_INSTANCE_UUID
+            echo "The value of 'GMCLOUD_SAAS_INSTANCE_ADB_SERIAL_PORT' is: $GMCLOUD_SAAS_INSTANCE_ADB_SERIAL_PORT
+    - git::https://github.com/Genymobile/bitrise-step-genymotion-cloud-saas-stop.git:
+          title: "Genymotion Cloud SaaS Stop"
+          description: |-
+           Stop Genymotion Cloud SaaS Android Devices.
+          inputs:
+          - instance_uuid: $GMCLOUD_SAAS_INSTANCE_UUID
+    
+  test-several-devices-with-adb-serial-port:
+    title: "Test Several Devices with ADB Serial Port"
+    description: "This step tests that the user can login and start several devices with specific ADB serial port."
     steps:
     - change-workdir:
         title: Switch working dir to test / _tmp dir

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ app:
   envs:
   # If you want to share this step into a StepLib
   - BITRISE_STEP_ID: genymotion-cloud-saas-start
-  - BITRISE_STEP_VERSION: "0.1.6"
+  - BITRISE_STEP_VERSION: "0.1.7"
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/genymobile/bitrise-step-genymotion-cloud-saas-start.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: git@github.com:Genymobile/bitrise-steplib.git
   # Define these in your .bitrise.secrets.yml

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func getADBSerialFromJSON(jsonData string) string {
 }
 
 func getInstanceDetails(name string) (string, string) {
-	args := []string{"--format", "json", "instances", "list"}
+	args := buildGMSAASArgs("instances", "list")
 	jsonData, err := executeCLI(GMSaaSBinary, args...)
 	if err != nil {
 		setOperationFailed("Failed to get instances list, error: %s | output: %s\n", err, jsonData)
@@ -189,7 +189,7 @@ func login(api_token, username, password string) {
 func startInstanceAndConnect(wg *sync.WaitGroup, recipeUUID, instanceName, adbSerialPort string) {
 	var output Output
 	defer wg.Done()
-	args := []string{"--format", "json", "instances", "start", recipeUUID, instanceName}
+	args := buildGMSAASArgs("instances", "start", recipeUUID, instanceName)
 
 	jsonData, err := executeCLI(GMSaaSBinary, args...)
 	if err != nil {
@@ -205,9 +205,9 @@ func startInstanceAndConnect(wg *sync.WaitGroup, recipeUUID, instanceName, adbSe
 	// Connect to adb with adb-serial-port
 	var adbArgs []string
 	if adbSerialPort != "" {
-		adbArgs = []string{"--format", "json", "instances", "adbconnect", output.Instance.UUID, "--adb-serial-port", adbSerialPort}
+		adbArgs = buildGMSAASArgs("instances", "adbconnect", output.Instance.UUID, "--adb-serial-port", adbSerialPort)
 	} else {
-		adbArgs = []string{"--format", "json", "instances", "adbconnect", output.Instance.UUID}
+		adbArgs = buildGMSAASArgs("instances", "adbconnect", output.Instance.UUID)
 	}
 	
 	ADBjsonData, err := executeCLI(GMSaaSBinary, adbArgs...)
@@ -220,6 +220,10 @@ func startInstanceAndConnect(wg *sync.WaitGroup, recipeUUID, instanceName, adbSe
 	output.Instance.ADB_SERIAL = result["instance"].(map[string]interface{})["adb_serial"].(string)
 	
 	log.Infof("Genymotion instance UUID : %s has been started and connected with ADB Serial Port : %s", output.Instance.UUID, output.Instance.ADB_SERIAL)
+}
+
+func buildGMSAASArgs(args ...string) []string {
+	return append([]string{"--format", "json"}, args...)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"github.com/bitrise-io/go-steputils/tools"
-	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/log"
 )
 
@@ -152,10 +151,10 @@ func configureAndroidSDKPath() {
 
 	value, exists := os.LookupEnv("ANDROID_HOME")
 	if exists {
-		cmd := command.New("gmsaas", "config", "set", "android-sdk-path", value)
-		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+		args := buildGMSAASArgs("config", "set", "android-sdk-path", value)
+		out, err := executeCLI(GMSaaSBinary, args...)
 		if err != nil {
-			setOperationFailed("Failed to set android-sdk-path, error: error: %s | output: %s", cmd.PrintableCommandArgs(), err, out)
+			setOperationFailed("Failed to set android-sdk-path, error: %s | output: %s", err, out)
 			return
 		}
 		log.Infof("Android SDK is configured")
@@ -168,18 +167,18 @@ func configureAndroidSDKPath() {
 func login(api_token, username, password string) {
 	log.Infof("Login Genymotion Account")
 
-	var cmd *exec.Cmd
+	var args []string
 	if api_token != "" {
-		cmd = exec.Command("gmsaas", "auth", "token", api_token)
+		args = buildGMSAASArgs("auth", "token", api_token)
 	} else if username != "" && password != "" {
-		cmd = exec.Command("gmsaas", "auth", "login", username, password)
+		args = buildGMSAASArgs("auth", "login", username, password)
 	} else {
 		abortf("Invalid arguments. Must provide either a token or both email and password.")
 		return
 	}
-
-	if out, err := cmd.CombinedOutput(); err != nil {
-		abortf("Failed to login with gmsaas, error: error: %s | output: %s", cmd.Args, err, out)
+	_, err := executeCLI(GMSaaSBinary, args...)
+	if err != nil {
+		abortf("Failed to login, error: %s", err)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -98,16 +98,16 @@ func setOperationFailed(format string, args ...interface{}) {
 	isError = true
 }
 
-func executeCLI(binary string, args ...string) ([]byte, error) {
-	cmd := exec.Command(binary, args...)
-	
-	// Get output
-	output, err := cmd.Output()
-	if err != nil {
-		setOperationFailed("Fail to execute %w", err)
-		return nil, err
-	}
-	return output, nil
+func executeCLI(binary string, args ...string) ([]byte, []byte, error) {
+    cmd := exec.Command(binary, args...)
+
+    var stdoutBuf, stderrBuf strings.Builder
+    cmd.Stdout = &stdoutBuf
+    cmd.Stderr = &stderrBuf
+
+    err := cmd.Run()
+
+    return []byte(stdoutBuf.String()), []byte(stderrBuf.String()), err
 }
 
 func parseJSON(data []byte) (map[string]interface{}, error) {
@@ -129,14 +129,14 @@ func getADBSerialFromJSON(jsonData string) string {
 
 func getInstanceDetails(name string) (string, string) {
 	args := buildGMSAASArgs("instances", "list")
-	jsonData, err := executeCLI(GMSaaSBinary, args...)
+	stdout, stderr, err := executeCLI(GMSaaSBinary, args...)
 	if err != nil {
-		setOperationFailed("Failed to get instances list, error: %s | output: %s\n", err, jsonData)
+		setOperationFailed("Failed to get instances list, error: %s | stderr: %s | stdout: %s\n", err, stderr, stdout)
 		return "", ""
 	}
 	
 	// Parse the JSON response to get instance details
-	result, _ := parseJSON(jsonData)
+	result, _ := parseJSON(stdout)
 	for _, instances := range result["instances"].([]interface{}) {
 		instance := instances.(map[string]interface{})
 		if instance["name"] == name {
@@ -152,9 +152,9 @@ func configureAndroidSDKPath() {
 	value, exists := os.LookupEnv("ANDROID_HOME")
 	if exists {
 		args := buildGMSAASArgs("config", "set", "android-sdk-path", value)
-		out, err := executeCLI(GMSaaSBinary, args...)
+		stdout, stderr, err := executeCLI(GMSaaSBinary, args...)
 		if err != nil {
-			setOperationFailed("Failed to set android-sdk-path, error: %s | output: %s", err, out)
+			setOperationFailed("Failed to set android-sdk-path, error: %s | stderr: %s | stdout: %s", err, stderr, stdout)
 			return
 		}
 		log.Infof("Android SDK is configured")
@@ -176,9 +176,9 @@ func login(api_token, username, password string) {
 		abortf("Invalid arguments. Must provide either a token or both email and password.")
 		return
 	}
-	_, err := executeCLI(GMSaaSBinary, args...)
+	stdout, stderr, err := executeCLI(GMSaaSBinary, args...)
 	if err != nil {
-		abortf("Failed to login, error: %s", err)
+		abortf("Failed to login, error: %s | stderr: %s | stdout: %s\n", err, stderr, stdout)
 		return
 	}
 
@@ -190,14 +190,14 @@ func startInstanceAndConnect(wg *sync.WaitGroup, recipeUUID, instanceName, adbSe
 	defer wg.Done()
 	args := buildGMSAASArgs("instances", "start", recipeUUID, instanceName)
 
-	jsonData, err := executeCLI(GMSaaSBinary, args...)
+	stdout, stderr, err := executeCLI(GMSaaSBinary, args...)
 	if err != nil {
-		setOperationFailed("Failed to start a device, error: %s | output: %s\n", err, jsonData)
+		setOperationFailed("Failed to start a device, error: %s | stderr: %s | stdout: %s\n", err, stderr, stdout)
 		return
 	}
 	
 	// Parse the JSON response to get instance details
-	result, _ := parseJSON(jsonData) 
+	result, _ := parseJSON(stdout)
 	output.Instance.UUID = result["instance"].(map[string]interface{})["uuid"].(string)
 	output.Instance.ADB_SERIAL = result["instance"].(map[string]interface{})["adb_serial"].(string)
 
@@ -209,13 +209,13 @@ func startInstanceAndConnect(wg *sync.WaitGroup, recipeUUID, instanceName, adbSe
 		adbArgs = buildGMSAASArgs("instances", "adbconnect", output.Instance.UUID)
 	}
 	
-	ADBjsonData, err := executeCLI(GMSaaSBinary, adbArgs...)
+	adbStdout, adbStderr, err := executeCLI(GMSaaSBinary, adbArgs...)
 	if err != nil {
-		setOperationFailed("Failed to connect a device, error: %s | output: %s\n", err, ADBjsonData)
+		setOperationFailed("Failed to connect a device, error: %s | stderr: %s | stdout: %s\n", err, adbStderr, adbStdout)
 		return
 	}
 	
-	result, _ = parseJSON(ADBjsonData)
+	result, _ = parseJSON(adbStdout)
 	output.Instance.ADB_SERIAL = result["instance"].(map[string]interface{})["adb_serial"].(string)
 	
 	log.Infof("Genymotion instance UUID : %s has been started and connected with ADB Serial Port : %s", output.Instance.UUID, output.Instance.ADB_SERIAL)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 const (
 	GMCloudSaaSInstanceUUID          = "GMCLOUD_SAAS_INSTANCE_UUID"
 	GMCloudSaaSInstanceADBSerialPort = "GMCLOUD_SAAS_INSTANCE_ADB_SERIAL_PORT"
+	GMSaaSBinary                     = "gmsaas"
 )
 
 // Define variable
@@ -98,29 +99,49 @@ func setOperationFailed(format string, args ...interface{}) {
 	isError = true
 }
 
+func executeCLI(binary string, args ...string) ([]byte, error) {
+	cmd := exec.Command(binary, args...)
+	
+	// Get output
+	output, err := cmd.Output()
+	if err != nil {
+		setOperationFailed("Fail to execute %w", err)
+		return nil, err
+	}
+	return output, nil
+}
+
+func parseJSON(data []byte) (map[string]interface{}, error) {
+	var result map[string]interface{}
+	
+	if err := json.Unmarshal(data, &result); err != nil {
+		setOperationFailed("Issue with JSON parsing : %v", err)
+		return nil, err
+	}
+	return result, nil
+}
+
 func getADBSerialFromJSON(jsonData string) string {
 	var output Output
-	if err := json.Unmarshal([]byte(jsonData), &output); err != nil {
-		setOperationFailed("Issue with JSON parsing : %w", err)
-	}
+	result, _ := parseJSON([]byte(jsonData))
+	output.Instance.ADB_SERIAL = result["instance"].(map[string]interface{})["adb_serial"].(string)
 	return output.Instance.ADB_SERIAL
 }
 
 func getInstanceDetails(name string) (string, string) {
-	cmd := command.New("gmsaas", "--format", "json", "instances", "list")
-	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	args := []string{"--format", "json", "instances", "list"}
+	jsonData, err := executeCLI(GMSaaSBinary, args...)
 	if err != nil {
-		setOperationFailed("Failed to get instances list, error: error: %s | output: %s", cmd.PrintableCommandArgs(), err, out)
+		setOperationFailed("Failed to get instances list, error: %s | output: %s\n", err, jsonData)
 		return "", ""
 	}
-	var output Output
-	if err := json.Unmarshal([]byte(out), &output); err != nil {
-		setOperationFailed("Issue with JSON parsing : %w", err)
-	}
-
-	for _, instance := range output.Instances {
-		if instance.NAME == name {
-			return instance.UUID, instance.ADB_SERIAL
+	
+	// Parse the JSON response to get instance details
+	result, _ := parseJSON(jsonData)
+	for _, instances := range result["instances"].([]interface{}) {
+		instance := instances.(map[string]interface{})
+		if instance["name"] == name {
+			return instance["uuid"].(string), instance["adb_serial"].(string)
 		}
 	}
 	return "", ""
@@ -168,42 +189,37 @@ func login(api_token, username, password string) {
 func startInstanceAndConnect(wg *sync.WaitGroup, recipeUUID, instanceName, adbSerialPort string) {
 	var output Output
 	defer wg.Done()
-	cmd := command.New("gmsaas", "--format", "json", "instances", "start", recipeUUID, instanceName)
-	jsonData, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	args := []string{"--format", "json", "instances", "start", recipeUUID, instanceName}
+
+	jsonData, err := executeCLI(GMSaaSBinary, args...)
 	if err != nil {
 		setOperationFailed("Failed to start a device, error: %s | output: %s\n", err, jsonData)
 		return
 	}
-
-	if err := json.Unmarshal([]byte(jsonData), &output); err != nil {
-		setOperationFailed("Issue with JSON parsing : %s", err)
-	}
+	
+	// Parse the JSON response to get instance details
+	result, _ := parseJSON(jsonData) 
+	output.Instance.UUID = result["instance"].(map[string]interface{})["uuid"].(string)
+	output.Instance.ADB_SERIAL = result["instance"].(map[string]interface{})["adb_serial"].(string)
 
 	// Connect to adb with adb-serial-port
+	var adbArgs []string
 	if adbSerialPort != "" {
-		cmd := command.New("gmsaas", "--format", "json", "instances", "adbconnect", output.Instance.UUID, "--adb-serial-port", adbSerialPort)
-		ADBjsonData, err := cmd.RunAndReturnTrimmedCombinedOutput()
-		if err != nil {
-			setOperationFailed("Failed to connect a device, error: error: %s | output: %s", cmd.PrintableCommandArgs(), err, ADBjsonData)
-			return
-		}
-		if err := json.Unmarshal([]byte(ADBjsonData), &output); err != nil {
-			setOperationFailed("Issue with JSON parsing : %s", err)
-		}
+		adbArgs = []string{"--format", "json", "instances", "adbconnect", output.Instance.UUID, "--adb-serial-port", adbSerialPort}
 	} else {
-		cmd := command.New("gmsaas", "--format", "json", "instances", "adbconnect", output.Instance.UUID)
-		ADBjsonData, err := cmd.RunAndReturnTrimmedCombinedOutput()
-		if err != nil {
-			setOperationFailed("Failed to connect a device, error: error: %s | output: %s", cmd.PrintableCommandArgs(), err, ADBjsonData)
-			return
-		}
-		if err := json.Unmarshal([]byte(ADBjsonData), &output); err != nil {
-			setOperationFailed("Issue with JSON parsing : %s", err)
-		}
+		adbArgs = []string{"--format", "json", "instances", "adbconnect", output.Instance.UUID}
 	}
-
+	
+	ADBjsonData, err := executeCLI(GMSaaSBinary, adbArgs...)
+	if err != nil {
+		setOperationFailed("Failed to connect a device, error: %s | output: %s\n", err, ADBjsonData)
+		return
+	}
+	
+	result, _ = parseJSON(ADBjsonData)
+	output.Instance.ADB_SERIAL = result["instance"].(map[string]interface{})["adb_serial"].(string)
+	
 	log.Infof("Genymotion instance UUID : %s has been started and connected with ADB Serial Port : %s", output.Instance.UUID, output.Instance.ADB_SERIAL)
-
 }
 
 func main() {

--- a/step.yml
+++ b/step.yml
@@ -130,12 +130,12 @@ inputs:
           For example:
           `4321,4322,4323`
 
-  - gmsaas_version: "1.11.0"
+  - gmsaas_version: ""
     opts:
         title: gmsaas version
         summary: ""
         description: |-
-          Install a specific version of gmsaas, per default it will install the latest compatible gmsaas version : 1.11.0
+          Install a specific version of gmsaas, per default it will install the latest gmsaas version
 
 
 


### PR DESCRIPTION
We have detected some issues when parsing the json. When a stderr is present, it will send to the output which contains the json and it fails during the parsing. 

Now we separate stdout and stderr  into individual variables in order to display stderr only when command execution fails

We have created to new function ExecuteCLI and ParseJson to factorize and simplify the code. 

Add new tests. 